### PR TITLE
Attempt to fix nonresponsive player window toggler

### DIFF
--- a/src/nss/0i_win_layouts.nss
+++ b/src/nss/0i_win_layouts.nss
@@ -103,7 +103,8 @@ void SetupPlayerGUIPanel (object oPC, json jCol, float fWinWidth, float fWinHeig
 
 void PopUpPlayerHorGUIPanel (object oPC)
 {
-    if (SQLocalsPlayer_GetInt(oPC, "pc_menu_disabled") == 1)
+    string sKey = GetPCPublicCDKey(oPC, TRUE);
+    if (GetCampaignInt(sKey, "pc_menu_disabled") == 1)
         return;
 
     // ********** Create new Column *******


### PR DESCRIPTION
In the mix of per-character and per-account toggles I think some have got stuck - and with this reading the per-player variable and the toggler setting the per-account one, any character who still had the per-player toggle set to hidden would never have a player window visible