### PR TITLE
Fix for paths containing spaces in win_run_server.bat

### DIFF
--- a/win_run_server.bat
+++ b/win_run_server.bat
@@ -32,7 +32,7 @@ set content=
 for /f "delims=" %%x in ('type mod_desc.txt') do set "content=!content!%%x!LF!"
 set "content=!content!Last Updated: %timestamp% (%hash%)"
 
-"%CD%/tools/win/nasher/nasher.exe" install  --clean --verbose --erfUtil:"%CD%/tools/win/neverwinter64/nwn_erf.exe" --gffUtil:"%CD%/tools/win/neverwinter64/nwn_gff.exe" --tlkUtil:"%CD%/tools/win/neverwinter64/nwn_tlk.exe" --nssCompiler:"%CD%/tools/win/nwnsc/nwnsc.exe" --installDir:"%CD%" --nssFlags:"-oe -i %CD%/nwn-base-scripts" --no --modDescription "!content!"
+"%CD%/tools/win/nasher/nasher.exe" install  --clean --verbose --erfUtil:"%CD%/tools/win/neverwinter64/nwn_erf.exe" --gffUtil:"%CD%/tools/win/neverwinter64/nwn_gff.exe" --tlkUtil:"%CD%/tools/win/neverwinter64/nwn_tlk.exe" --nssCompiler:"%CD%/tools/win/nwnsc/nwnsc.exe" --installDir:"%CD%" --nssFlags:"-oe -i ""%CD%/nwn-base-scripts""" --no --modDescription "!content!"
 
 endlocal
 


### PR DESCRIPTION
This would cause the nasher build to fail and the server to not run if the path contained spaces.