### PR TITLE
Fix maker battle errors, log spam, and new PC item updates

### DIFF
--- a/src/git/ud_maker2.git.json
+++ b/src/git/ud_maker2.git.json
@@ -71290,7 +71290,7 @@
               },
               "Cost": {
                 "type": "dword",
-                "value": 35856
+                "value": 11556
               },
               "Cursed": {
                 "type": "byte",

--- a/src/nss/death_makerbgol.nss
+++ b/src/nss/death_makerbgol.nss
@@ -23,13 +23,21 @@ void MakeNewGolem(object oOne, object oTwo, location lMid)
     // Remove old ones from array
     if (GetIsObjectValid(oOne))
     {
-        int nIndex = JsonGetInt(JsonFind(jGolems, JsonString(ObjectToString(oOne))));
-        jGolems = JsonArrayDel(jGolems, nIndex);
+        json jResponse = JsonFind(jGolems, JsonString(ObjectToString(oOne)));
+        if (jResponse != JsonNull())
+        {
+            int nIndex = JsonGetInt(jResponse);
+            jGolems = JsonArrayDel(jGolems, nIndex);
+        }
     }
     if (GetIsObjectValid(oTwo))
     {
-        int nIndex = JsonGetInt(JsonFind(jGolems, JsonString(ObjectToString(oTwo))));
-        jGolems = JsonArrayDel(jGolems, nIndex);
+        json jResponse = JsonFind(jGolems, JsonString(ObjectToString(oTwo)));
+        if (jResponse != JsonNull())
+        {
+            int nIndex = JsonGetInt(jResponse);
+            jGolems = JsonArrayDel(jGolems, nIndex);
+        }
     }
     
     SetLocalJson(oArea, "maker_golems", jGolems);
@@ -48,12 +56,12 @@ void main()
         return;
     }
     // Look for another dead one
-    int n=1;
+    int n=0;
     object oOther;
     do
     {
-        object oOther = GetNearestObjectByTag(GetTag(OBJECT_SELF), OBJECT_SELF, n);
-        if (GetIsDead(oOther) && GetIsObjectValid(oOther))
+        oOther = GetNearestObjectByTag(GetTag(OBJECT_SELF), OBJECT_SELF, n);
+        if (GetIsDead(oOther) && GetIsObjectValid(oOther) && oOther != OBJECT_SELF)
         {
             if (!GetLocalInt(oOther, "tethering"))
             {

--- a/src/nss/dlg_buff.nss
+++ b/src/nss/dlg_buff.nss
@@ -5,14 +5,17 @@ void main()
 
     if (GetIsDeveloper(oPC))
     {
-        SendDiscordLogMessage(GetName(oPC) + " used the developer menu to apply various OP buffs to themselves, permanently.");
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectAttackIncrease(20), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectDamageIncrease(30), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectMovementSpeedIncrease(99), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectTemporaryHitpoints(200), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectHaste(), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectSkillIncrease(SKILL_SEARCH, 50), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectSkillIncrease(SKILL_LORE, 50), oPC);
-        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectSkillIncrease(SKILL_PERSUADE, 50), oPC);
+        SendDiscordLogMessage(GetName(oPC) + " used the developer menu to apply various OP buffs to themselves.");
+        effect eLink = EffectAttackIncrease(20);
+        eLink = EffectLinkEffects(eLink, EffectDamageIncrease(30));
+        eLink = EffectLinkEffects(eLink, EffectDamageImmunityIncrease(4095, 90));
+        eLink = EffectLinkEffects(eLink, EffectSpellResistanceIncrease(28));
+        eLink = EffectLinkEffects(eLink, EffectMovementSpeedIncrease(99));
+        eLink = EffectLinkEffects(eLink, EffectTemporaryHitpoints(200));
+        eLink = EffectLinkEffects(eLink, EffectHaste());
+        eLink = EffectLinkEffects(eLink, EffectSkillIncrease(SKILL_SEARCH, 50));
+        eLink = EffectLinkEffects(eLink, EffectSkillIncrease(SKILL_LORE, 50));
+        eLink = EffectLinkEffects(eLink, EffectSkillIncrease(SKILL_PERSUADE, 50));
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, SupernaturalEffect(eLink), oPC, 3600.0);
     }
 }

--- a/src/nss/hb_maker.nss
+++ b/src/nss/hb_maker.nss
@@ -79,11 +79,13 @@ void main()
     int nDR = 0;
     int nHP = GetCurrentHitPoints();
     int nLastHP = GetLocalInt(OBJECT_SELF, "last_hp");
+    if (nLastHP == 0)
+        nLastHP = GetMaxHitPoints();
     int nLastDR = GetLocalInt(OBJECT_SELF, "last_dr");
     effect eTest = GetFirstEffect(OBJECT_SELF);
     while (GetIsEffectValid(eTest))
     {
-        if (GetEffectType(eTest) == EFFECT_TYPE_DAMAGE_REDUCTION)
+        if (GetEffectType(eTest) == EFFECT_TYPE_DAMAGE_RESISTANCE)
         {
             nDR += GetEffectInteger(eTest, 2);
         }
@@ -95,6 +97,8 @@ void main()
     if (nHPDelta <= 0) { nHPDelta = 0; }
     int nDRDelta = nLastDR - nDR;
     if (nDRDelta <= 0) { nDRDelta = 0; }
+    
+    //SpeakString("HP delta " + IntToString(nHPDelta) + " DR delta " + IntToString(nDRDelta) + ", current values " + IntToString(nHP) + " " + IntToString(nDR));
 
     // This is deliberately built to make doing damage
     // to the maker rapidly cause him to be more inclined to make golems
@@ -107,10 +111,13 @@ void main()
     // Actual HP damage counts for more
     // Dispelling premonition/stoneskin will count as a massive damage spike...
     int nEHPDelta = nHPDelta*2 + nDRDelta;
+    
 
     int nGolemPoints = FloatToInt(pow(IntToFloat(nEHPDelta), 1.4));
     int nOldGolemPoints = GetLocalInt(OBJECT_SELF, "golem_points");
     nGolemPoints += nOldGolemPoints;
+    nGolemPoints += 4;
+    //SpeakString("Golem points: " + IntToString(nGolemPoints));
     float fDelay = 0.0;
     while (nGolemPoints > 400)
     {

--- a/src/nss/inc_cdkeyvars.nss
+++ b/src/nss/inc_cdkeyvars.nss
@@ -534,7 +534,7 @@ void UpdateOldestCachedCdkeyDB()
     {
         string sDatabase = SqlGetString(sql, 0);
         // Todo: remove this once sure it works with multiple players online
-        WriteTimestampedLogEntry("Oldest cached cdkeydb = " + sDatabase);
+        //WriteTimestampedLogEntry("Oldest cached cdkeydb = " + sDatabase);
         // If this returns 1, it updated the database
         // If it didn't, it removed the database from cdkeycache__update
         // and doing this lookup again will find something different (or nothing)

--- a/src/nss/on_client_ent.nss
+++ b/src/nss/on_client_ent.nss
@@ -171,5 +171,5 @@ void main()
     }
 
     ShowOrHideXPBarUI(oPC);
-    UpdatePCOwnedItemProperties(oPC);
+    UpdatePCOwnedItemProperties(oPC, GetHitDice(oPC) > 1);
 }

--- a/src/nss/on_client_ent.nss
+++ b/src/nss/on_client_ent.nss
@@ -92,6 +92,8 @@ void main()
 
     //SetEventScript(oPC,EVENT_SCRIPT_CREATURE_ON_MELEE_ATTACKED,"70_mod_attacked");
     //SetEventScript(oPC,EVENT_SCRIPT_CREATURE_ON_DAMAGED,"70_mod_damaged");
+    
+    int bIsNewCharacter = FALSE;
 
 // If the PC has more than 0 XP, then do this.
 // Safe to assume a non-new character in this way.
@@ -144,6 +146,7 @@ void main()
 // otherwise, assume they're new and do the whole new PC routine
     else
     {
+        bIsNewCharacter = TRUE;
         DelayCommand(0.01, ExecuteScript("new_character", oPC));
     }
 
@@ -171,5 +174,5 @@ void main()
     }
 
     ShowOrHideXPBarUI(oPC);
-    UpdatePCOwnedItemProperties(oPC, GetHitDice(oPC) > 1);
+    UpdatePCOwnedItemProperties(oPC, !bIsNewCharacter);
 }

--- a/src/uti/cre_golemclaysk.uti.json
+++ b/src/uti/cre_golemclaysk.uti.json
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 6728000
+    "value": 4105638
   },
   "Cursed": {
     "type": "byte",
@@ -130,7 +130,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 7
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -161,7 +161,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 7
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -445,5 +445,9 @@
   "TemplateResRef": {
     "type": "resref",
     "value": "cre_golemclaysk"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 1
   }
 }


### PR DESCRIPTION
The Maker:

* Fixed something that happened in the fight sometimes persisting through area refreshing.
* Fixed an error in the determination of how often the Maker did his new thing, and slightly rebalanced the overall rate of thing occurences. This most likely makes the fight a little harder - especially for those who kill him without depleting his physical protections.

Other:

* Clay golems now only have 50% immunity to piercing/slashing.
* Prevent level 1 PCs that are just joining getting item updates if the item updater wants to have a go at one of their starting items.
* Silence cdkey update writes in the log that were very spammy.
